### PR TITLE
Change name to mse

### DIFF
--- a/R/rmse.R
+++ b/R/rmse.R
@@ -1,8 +1,8 @@
 rmse <- function(obs, pred){
   #calculate root-mean-squared-error
   sqr.error <- (obs - pred)^2
-  mn.sqr.error <- mean(sqr.error)
-  rmse <- sqrt(mn.sqr.error)
+  mse <- mean(sqr.error)
+  rmse <- sqrt(mse)
   return(rmse)
 }
 


### PR DESCRIPTION
I changed the variable name for the mean squared error to "mse". I made this change because I was told to make a change. @wdwatkins 